### PR TITLE
Expose each service as well as via the proxy.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,8 @@ services:
     environment:
       - VIRTUAL_HOST=local-admin.cotejs.org, ws://local-admin.cotejs.org
       - BALANCE=source
-    expose:
-      - 5000
+    ports:
+      - 5000:5000
 
   end-user:
     extends: base
@@ -35,8 +35,8 @@ services:
     environment:
       - VIRTUAL_HOST=local-end-user.cotejs.org, ws://local-end-user.cotejs.org
       - BALANCE=source
-    expose:
-      - 5001
+    ports:
+      - 5001:5001
 
   monitoring:
     extends: base
@@ -44,8 +44,8 @@ services:
     environment:
       - PORT=80
       - VIRTUAL_HOST=local-monitoring.cotejs.org
-    expose:
-      - 5555
+    ports:
+      - 5555:5555
 
   payment-service:
     extends: base


### PR DESCRIPTION
The Readme was designed to be run with out docker so
all the ports/links/urls by default have http://localhost:5000 for each service. So in order to make it a better experience I would expose the internal ports as well.