### PR TITLE
Change git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The client interface is implemented entirely in cote; the server only serves a s
 Run the following commands:
 
 ```
-git clone git@github.com:dashersw/cote-workshop.git
+git clone https://github.com/dashersw/cote-workshop
 cd cote-workshop
 npm install
 node init-db.js


### PR DESCRIPTION
Hi.
`git clone git@github.com:dashersw/cote-workshop.git` requires an SSH key. I switched it to the HTTPS method as it doesn't require generating an SSH key.